### PR TITLE
Commitlog separation

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,6 @@
+#
+# Installation:
+#   $ export OTP_GITHUB_URL="https://github.com/basho/otp"
+#   $ asdf install erlang R16B02_basho8
+#
+erlang R16B02_basho8

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ ls-releases:
 
 .PHONY:help
 help:
-	@echo "If you're here to install the postcommit hook to your local Riak run"
-	@echo "  ./post-commit-hooks copy-to-dev-services"
+	@echo "If you're here to install the postcommit hook to your local dev-services Riak run"
+	@echo "  make install"
 	@echo ""
 	@echo "Otherwise? Your available commands: clean, distclean, compile, install, release, help"

--- a/src/postcommit_hook.erl
+++ b/src/postcommit_hook.erl
@@ -20,6 +20,7 @@ send_to_kafka_riak_commitlog(Object) ->
 
     TimingResult = try
         {Timing, ok} = timer:tc(?MODULE, sync_to_commitlog, [Action, Bucket, Key, Value]),
+        error_logger:info_msg("[commitlog] sync_to_commitlog success. Bucket: ~p. Key: ~p.", [Bucket, Key]),
         Timing
     catch
         _:SyncException ->
@@ -77,7 +78,11 @@ send_timing_to_statsd(Timing) ->
          end.
 
 remote_node() ->
-    [_Name, IP] = string:tokens(atom_to_list(node()), "@"),
-    Remote = "commitlog" ++ "@" ++ IP,
+    Hostname = case os:getenv("COMMITLOG_HOSTNAME") of
+                   false -> [_Name, Host] = string:tokens(atom_to_list(node()), "@"),
+                            Host;
+                   EnvHost -> EnvHost
+               end,
+    Remote = "commitlog" ++ "@" ++ Hostname,
     list_to_atom(Remote).
 


### PR DESCRIPTION
[EFS-104: Enable upgrading CommitLog independent of PCH](https://spreedly.atlassian.net/browse/EFS-104)

Currently, Post-commit Hook (PCH) and Commitlog (CL) run within the CDE
on every Riak node and communicate with each other directly via Erlang
messaging without hitting the network. A consequence of this design is
that updates to CL require that we take down every Riak node (which is
a time-consuming manual process). As part of the AWS migration we want
to decouple CL from Riak / PCH, so they can be upgraded and scaled
independently. This requires configuring PCH so it can find CL on the
network.

Going forward, PCH will retrieve the CL hostname from an environment
variable, `COMMITLOG_HOSTNAME`, falling back to the Erlang host returned
by `node().` if the env var is not set. In other words, unless the env
var is set, PCH will expect CL to run on the same host as Riak; e.g. for
dev-services.

- defaults to the Erlang host from `node().`
- log bucket and key for successful calls to Commitlog
- update `make help` output
