### PR TITLE
EFS-136 Refactoring in preparation for managed retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,26 @@ $ s3cmd --configure # use the "kafka-integration S3 credentials" from the 1Passw
 $ make release # compiles, tars up the release, pushes to S3
 ```
 
+
+## Tests
+
+Tests are run automatically when you compile the project using `make`.
+
+### Manually run all tests
+
+To run all the tests (without compiling the project):
+
+```
+$ make test
+```
+
+### Manually run specific tests
+
+To run specific tests:
+
+```
+$ ./rebar eunit tests=postcommit_hook:TEST_NAME
+
+# For example:
+#   ./rebar eunit tests=postcommit_hook:call_commitlog_test_
+```


### PR DESCRIPTION
This PR represents a deployable branch containing only refactored code in preparation for adding retries and retry management.

As far as I know, the only behavior that changed is:
 - always send timing to statsd
 - logging output

The most notable change is to push try/catch expressions into the functions that could throw and return error tuples instead.

There are lots of individual commits so you can see how the code evolved.