### PR TITLE
EFS-136 Retry Commitlog failures

### DIFF
--- a/src/postcommit_hook.erl
+++ b/src/postcommit_hook.erl
@@ -1,5 +1,10 @@
 -module(postcommit_hook).
--export([send_to_kafka_riak_commitlog/1, send_to_commitlog/1, call_commitlog/1, do_call_commitlog/1]).
+-export([send_to_kafka_riak_commitlog/1,
+         send_to_commitlog_with_retries/3,
+         retry_send_to_commitlog/3,
+         send_to_commitlog/1,
+         call_commitlog/1,
+         do_call_commitlog/1]).
 
 -include("src/postcommit_hook.hrl").
 
@@ -16,21 +21,52 @@ send_to_kafka_riak_commitlog(RiakObject) ->
     case build_commitlog_request(RiakObject) of
         {ok, Request} ->
             Call = {{?COMMITLOG_PROCESS, commitlog_node()}, Request},
-            {MicroTime, Result} = timer:tc(?MODULE, send_to_commitlog, [Call]),
+            {MicroTime,
+             {Result, Attempts}} = timer:tc(?MODULE, send_to_commitlog_with_retries,
+                                            [Call, 0, ?INITIAL_RETRY_DELAY_MS]),
             Time = round(MicroTime / 1000),
             case Result of
                 ok ->
-                    log(info, "Send to Commitlog succeeded. Time: ~w ms.",
-                        [Time], Call);
+                    log(info, "Send to Commitlog succeeded. Time: ~w ms. Attempts: ~w.",
+                        [Time, Attempts], Call);
                 {error, Error} ->
-                    log(warn, "Send to Commitlog failed. Time: ~w ms. Error: ~w.",
-                        [Time, Error], Call)
+                    log(warn, "Send to Commitlog failed. Time: ~w ms. Attempts: ~w. Error: ~w.",
+                        [Time, Attempts, Error], Call)
             end,
             Result;
         {error, RiakObjectError} ->
             log(warn, "Unable to extract data from Riak object '~w': ~w.",
                 [RiakObject, RiakObjectError]),
             {error, RiakObjectError}
+    end.
+
+send_to_commitlog_with_retries(Call, NumAttempts, Delay) ->
+    Result = ?MODULE:send_to_commitlog(Call),
+    Attempts = NumAttempts + 1,
+    case Result of
+        ok ->
+            {ok, Attempts};
+        {error, Error} ->
+            log(info, "Unable to send to Commitlog. Attempts: ~p. Error: ~w.",
+                [Attempts, Error], Call),
+            case Attempts of
+                % All attempts failed, return error
+                ?MAX_ATTEMPTS -> {{error, Error}, Attempts};
+
+                % First attempt failed, try again
+                1 -> seed_rng(), ?MODULE:retry_send_to_commitlog(Call, Attempts, Delay);
+
+                % Other attempt failed, try again
+                _ -> ?MODULE:retry_send_to_commitlog(Call, Attempts, Delay)
+            end
+    end.
+
+retry_send_to_commitlog(Call, NumAttempts, Delay) ->
+    receive
+    after
+        Delay ->
+            NextDelay = jitter(Delay * ?RETRY_DELAY_MULTIPLIER, ?RETRY_DELAY_JITTER),
+            ?MODULE:send_to_commitlog_with_retries(Call, NumAttempts, NextDelay)
     end.
 
 send_to_commitlog(Call) ->
@@ -40,7 +76,9 @@ send_to_commitlog(Call) ->
 
 call_commitlog(Call) ->
     try ?MODULE:do_call_commitlog(Call)
-    catch _:E -> {error, E}
+    catch
+        _:{Error, {gen_server, call, _}} -> {error, Error};
+        _:Error -> {error, Error}
     end.
 
 %% gen_server:call({kafka_riak_commitlog, 'commitlog@127.0.0.1'},
@@ -66,6 +104,20 @@ log(info, Format, Data, Bucket, Key) ->
     error_logger:info_msg(?LOG_MSG_FMT, [io_lib:format(Format, Data), Bucket, Key]);
 log(warn, Format, Data, Bucket, Key) ->
     error_logger:warning_msg(?LOG_MSG_FMT, [io_lib:format(Format, Data), Bucket, Key]).
+
+%% Seeding is necessary to avoid a race condition where multiple postcommit-
+%% hook processes automatically seed the RNG in the same manner and all use the
+%% same seed, which defeats the purpose of adding jitter.
+seed_rng() ->
+    {_, Seconds, MicroSecs} = now(),
+    random:seed(erlang:phash2(self()), Seconds, MicroSecs).
+
+%% Returns N ± N*Percent. For example, `jitter(100, 0.1)` returns a number in
+%% the interval [90, 110].
+jitter(N, Percent) when 0.0 =< Percent andalso Percent =< 1.0 ->
+    round(N * (1.0 - Percent + (random:uniform() * Percent * 2.0)));
+jitter(_N, _Percent) ->
+    error({badarg, "Percent must be in the interval [0.0, 1.0]"}).
 
 build_commitlog_request(RiakObject) ->
     try
@@ -117,6 +169,21 @@ commitlog_node() ->
 %% ---------------------------------------------------------------------------
 
 -ifdef(TEST).
+
+jitter_test_() ->
+    [{"Returns N ± N*Percent.",
+      fun() ->
+              J = jitter(100, 0.1),
+              ?assert(90 =< J andalso J =< 110)
+      end},
+     {"Returns error when Percent is < 0",
+      fun() ->
+              ?assertError({badarg, _}, jitter(1, -0.1))
+      end},
+     {"Returns error when Percent is > 1",
+      fun() ->
+              ?assertError({badarg, _}, jitter(1, 1.1))
+      end}].
 
 build_commitlog_request_test_() ->
     {foreach,

--- a/src/postcommit_hook.hrl
+++ b/src/postcommit_hook.hrl
@@ -1,3 +1,9 @@
 -define(COMMITLOG_PROCESS, kafka_riak_commitlog).
+
+-define(INITIAL_RETRY_DELAY_MS, 100).
+-define(MAX_ATTEMPTS, 6).
+-define(RETRY_DELAY_JITTER, 0.15).
+-define(RETRY_DELAY_MULTIPLIER, 2.0).
+
 -define(STATSD_HOST, "127.0.0.1").
 -define(STATSD_PORT, 8125).


### PR DESCRIPTION
This PR build upon #23. It contains incremental commits and refactoring to improve upon the previous attempt at retrying failed Commitlog sends (#18).

Retry management (improving on #19) will go in a separate PR, but will need to be combined with this one before merging to master.